### PR TITLE
Fix app icon install destionation

### DIFF
--- a/mdiedit/CMakeLists.txt
+++ b/mdiedit/CMakeLists.txt
@@ -26,7 +26,7 @@ set(DESKTOP_FILES
 	desktop_files/mdiedit.desktop
 )
 
-set(ICON_FILES
+set(APP_ICON_FILES
 	desktop_files/mdiedit.svg
 )
 
@@ -118,7 +118,7 @@ endif()
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 install(FILES ${CONFIG_FILES} DESTINATION ${APP_SHARE_DIR})
 install(FILES ${DESKTOP_FILES} DESTINATION share/applications)
-install(FILES ${ICON_FILES} DESTINATION share/icons)
+install(FILES ${APP_ICON_FILES} DESTINATION share/icons/hicolor/scalable/apps)
 install(FILES ${TRANSLATIONS_FILES} DESTINATION share/mdiedit/translations-qm)
 
 # building tarball with CPack -------------------------------------------------


### PR DESCRIPTION
QIcon::fromTheme() doesn't search in /usr/share/icons. And it shouldn't.
It also don't search in /usr/share/pixmaps and it should. The proper
solution is to install the icon to the default theme (hicolor). This
way all the icon engines can find it.
